### PR TITLE
Disable TBB thread observer in PostEndJob watcher

### DIFF
--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -771,6 +771,11 @@ namespace edm {
 
       if (not threadTracker_) {
         threadTracker_ = std::make_unique<ThreadTracker>();
+        iReg.watchPostEndJob([]() {
+          if (threadTracker_) {
+            threadTracker_->observe(false);
+          }
+        });
       }
 
       if (unloadSigHandler_) {

--- a/HLTrigger/Timer/plugins/FastTimerService.cc
+++ b/HLTrigger/Timer/plugins/FastTimerService.cc
@@ -1101,6 +1101,8 @@ void FastTimerService::postSourceLumi(edm::LuminosityBlockIndex index) {
 }
 
 void FastTimerService::postEndJob() {
+  // stop observing to avoid potential race conditions at exit
+  tbb::task_scheduler_observer::observe(false);
   guard_.finalize();
   if (print_job_summary_) {
     edm::LogVerbatim out("FastReport");


### PR DESCRIPTION
#### PR description:

According to comments in the [TBB source](https://github.com/oneapi-src/oneTBB/blob/9e15720bc7744f85dff611d34d65e9099e077da4/include/oneapi/tbb/task_scheduler_observer.h#L87-L94) "It is recommended to disable observation before destructor of a derived class starts, otherwise it can lead to concurrent notification callback on partly destroyed object".  This PR implements disabling observation in PostEndJob watchers.

#### PR validation:

Compiles, currently running tests.