### PR TITLE
Use ROOT lossy compression for P3 and position of reco::Track

### DIFF
--- a/DataFormats/TrackReco/interface/TrackBase.h
+++ b/DataFormats/TrackReco/interface/TrackBase.h
@@ -55,6 +55,7 @@
 #include "DataFormats/Math/interface/Vector3D.h"
 #include "DataFormats/Math/interface/Point3D.h"
 #include "DataFormats/Math/interface/Error.h"
+#include "Rtypes.h"
 #include <bitset>
 
 namespace reco {
@@ -453,7 +454,7 @@ namespace reco {
     HitPattern hitPattern_;
 
     /// perigee 5x5 covariance matrix
-    float covariance_[covarianceSize];
+    Float16_t covariance_[covarianceSize];  //[0,0,9]
 
     /// errors for time and velocity (separate from cov for now)
     float covt0t0_, covbetabeta_;

--- a/DataFormats/TrackReco/src/TrackMomentumStorage.h
+++ b/DataFormats/TrackReco/src/TrackMomentumStorage.h
@@ -1,0 +1,42 @@
+#ifndef DataFormats_TrackReco_TrackMomentumStorage_h
+#define DataFormats_TrackReco_TrackMomentumStorage_h
+// -*- C++ -*-
+//
+// Package:     DataFormats/TrackReco
+// Class  :     TrackMomentumStorage
+//
+/**\class TrackMomentumStorage TrackMomentumStorage.h "TrackMomentumStorage.h"
+
+ Description: Floating point lossy compressed cartesian 3d
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Mon, 12 Sep 2022 15:12:10 GMT
+//
+
+// system include files
+
+// user include files
+#include "Rtypes.h"
+
+// forward declarations
+namespace reco {
+  namespace storage {
+    struct TrackMomentumValues {
+      TrackMomentumValues() : fX(0.), fY(0.), fZ(0.) {}
+      Double32_t fX;  //[0,0,9]
+      Double32_t fY;  //[0,0,9]
+      Double32_t fZ;  //[0,0,9]
+    };
+
+    struct TrackMomentumStorage {
+    public:
+      TrackMomentumValues fCoordinates;
+    };
+  }  // namespace storage
+}  // namespace reco
+#endif

--- a/DataFormats/TrackReco/src/TrackPositionStorage.h
+++ b/DataFormats/TrackReco/src/TrackPositionStorage.h
@@ -1,0 +1,42 @@
+#ifndef DataFormats_TrackReco_TrackPositionStorage_h
+#define DataFormats_TrackReco_TrackPositionStorage_h
+// -*- C++ -*-
+//
+// Package:     DataFormats/TrackReco
+// Class  :     TrackPositionStorage
+//
+/**\class TrackPositionStorage TrackPositionStorage.h "TrackPositionStorage.h"
+
+ Description: Floating point lossy compressed cartesian 3d
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Mon, 12 Sep 2022 15:12:10 GMT
+//
+
+// system include files
+
+// user include files
+#include "Rtypes.h"
+
+// forward declarations
+namespace reco {
+  namespace storage {
+    struct TrackPositionValues {
+      TrackPositionValues() : fX(0.), fY(0.), fZ(0.) {}
+      Double32_t fX;  //[-150,150,21]
+      Double32_t fY;  //[-150,150,21]
+      Double32_t fZ;
+    };
+
+    struct TrackPositionStorage {
+    public:
+      TrackPositionValues fCoordinates;
+    };
+  }  // namespace storage
+}  // namespace reco
+#endif

--- a/DataFormats/TrackReco/src/classes.h
+++ b/DataFormats/TrackReco/src/classes.h
@@ -30,5 +30,7 @@
 #include "DataFormats/TrackCandidate/interface/TrackCandidate.h"
 #include "DataFormats/TrackReco/interface/DeDxHitInfo.h"
 #include "DataFormats/TrackReco/interface/SeedStopInfo.h"
+#include "DataFormats/TrackReco/src/TrackMomentumStorage.h"
+#include "DataFormats/TrackReco/src/TrackPositionStorage.h"
 
 #include <vector>

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -1,5 +1,17 @@
 <lcgdict>
 
+  <class name="reco::storage::TrackMomentumValues" ClassVersion="3">
+    <version ClassVersion="3" checksum="1395696012"/>
+  </class>
+  <class name="reco::storage::TrackMomentumStorage" ClassVersion="3">
+      <version ClassVersion="3" checksum="4153617590"/>
+  </class>
+  <class name="reco::storage::TrackPositionValues" ClassVersion="3">
+    <version ClassVersion="3" checksum="2169718810"/>
+  </class>
+  <class name="reco::storage::TrackPositionStorage" ClassVersion="3">
+      <version ClassVersion="3" checksum="1497277170"/>
+  </class>
   <class name="reco::TrackBase::AlgoMask"/>
   <class name="reco::HitPattern" ClassVersion="13">
       <version ClassVersion="13" checksum="2211596316"/>
@@ -10,7 +22,8 @@
    <version ClassVersion="11" checksum="639174599"/>
    <version ClassVersion="10" checksum="2022291691"/>
   </class>
-  <class name="reco::TrackBase" ClassVersion="20">
+  <class name="reco::TrackBase" ClassVersion="21">
+   <version ClassVersion="21" checksum="3833889643"/>
    <version ClassVersion="20" checksum="1589774059"/>
    <version ClassVersion="19" checksum="4090229239"/>
    <version ClassVersion="18" checksum="1935215297"/>
@@ -20,12 +33,10 @@
    <version ClassVersion="14" checksum="3929365050"/>
    <version ClassVersion="13" checksum="1244921154"/>
    <version ClassVersion="12" checksum="2704717983"/>
-    <field name="vertex_" iotype="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
-    <field name="momentum_" iotype="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
+    <field name="vertex_" iotype="reco::storage::TrackPositionStorage" /> 
+    <field name="momentum_" iotype="reco::storage::TrackMomentumStorage" /> 
 
    <version ClassVersion="10" checksum="3019978065"/>
-    <field name="vertex_" iotype="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
-    <field name="momentum_" iotype="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
   </class>
  <ioread
     sourceClass="reco::HitPattern"
@@ -335,7 +346,8 @@
   <class name="edm::Ref<std::vector<reco::TrackExtra>,reco::TrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackExtra>,reco::TrackExtra> >"/>
   <class name="edm::RefVector<std::vector<reco::TrackExtra>,reco::TrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackExtra>,reco::TrackExtra> >"/>
 
-  <class name="reco::Track" ClassVersion="20">
+  <class name="reco::Track" ClassVersion="21">
+   <version ClassVersion="21" checksum="1302304888"/>
    <version ClassVersion="20" checksum="2864582648"/>
    <version ClassVersion="19" checksum="362503460"/>
    <version ClassVersion="18" checksum="3235158110"/>


### PR DESCRIPTION
#### PR description:

- added classes used by ROOT when doing storage which specify lossy compression
- added iotypes rule to use new classes


#### PR validation:

Code compiles. Size comparison done using WF 11834.21.